### PR TITLE
Adding create_tasks_table in Migration

### DIFF
--- a/database/migrations/2021_09_03_105107_create_tasks_table.php
+++ b/database/migrations/2021_09_03_105107_create_tasks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            // $table->id();
+            $table->increments('id');
+            $table->integer('user_id')->index();
+            $table->string('name');
+            $table->string('image');
+            $table->boolean('is_done')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tasks');
+    }
+}


### PR DESCRIPTION
Added create_tasks_table in Database/Migration. As for the Tasks table, the attributes I used for this are placeholders which are as follows

![unknown](https://user-images.githubusercontent.com/74040104/131995748-9767311d-6f72-4d26-b96c-2c939c6fd01a.png)
